### PR TITLE
feat: handle ResourceDictionary subclasses in XAML

### DIFF
--- a/src/Compiler/Compiler/2_ConvertingXamlToCSharp/GeneratingCSharpCode.Pass2.cs
+++ b/src/Compiler/Compiler/2_ConvertingXamlToCSharp/GeneratingCSharpCode.Pass2.cs
@@ -332,7 +332,12 @@ namespace DotNetForHtml5.Compiler
                 );
                 bool isInitializeTypeFromString =
                     element.Attribute(InsertingImplicitNodes.InitializedFromStringAttribute) != null;
-                bool isResourceDictionary = IsResourceDictionary(element);
+
+                string rdNamespaceName, rdLocalTypeName, rdAssemblyNameIfAny;
+                GettingInformationAboutXamlTypes.GetClrNamespaceAndLocalName("ResourceDictionary", out rdNamespaceName,
+                    out rdLocalTypeName, out rdAssemblyNameIfAny);
+                bool isResourceDictionary = _reflectionOnSeparateAppDomain.IsTypeAssignableFrom(namespaceName,
+                    localTypeName, assemblyNameIfAny, rdNamespaceName, rdLocalTypeName, rdAssemblyNameIfAny);
                 bool isResourceDictionaryReferencedBySourceURI =
                     isResourceDictionary && element.Attribute("Source") != null;
 

--- a/src/Compiler/Compiler/2_ConvertingXamlToCSharp/GeneratingCSharpCode.cs
+++ b/src/Compiler/Compiler/2_ConvertingXamlToCSharp/GeneratingCSharpCode.cs
@@ -410,8 +410,6 @@ public sealed class {factoryName} : {IXamlComponentFactoryClass}<{componentTypeF
 
         public static bool IsControlTemplate(XElement element) => IsXElementOfType(element, "ControlTemplate");
 
-        public static bool IsResourceDictionary(XElement element) => IsXElementOfType(element, "ResourceDictionary");
-
         public static bool IsBinding(XElement element) => IsXElementOfType(element, "Binding");
 
         public static bool IsStyle(XElement element) => IsXElementOfType(element, "Style");


### PR DESCRIPTION
The Compiler used to look for elements named ResourceDictionary, now it
also accepts subclasses.